### PR TITLE
fix(cli): adapt to shadcn template drift breaking TanStack Start and Next.js scaffolds

### DIFF
--- a/.changeset/clever-moons-dance.md
+++ b/.changeset/clever-moons-dance.md
@@ -1,0 +1,8 @@
+---
+"create-tauri-ui": patch
+---
+
+Fix scaffolding failures caused by upstream template drift in the shadcn templates.
+
+- **TanStack Start**: scaffolding aborted with "Could not mount ExternalLinkGuard in the TanStack Start root route." The template now ships a `notFoundComponent` containing its own `<main>` element before `RootDocument`, and the scroll-container battery's "upgrade an existing `<main>`" path matched the first `<main>` in the file — tagging the 404 page's `<main>` with `data-ui-scroll-container` instead of wrapping `{children}`. The external-link-guard battery then failed because `<main>{children}</main>` never existed. The upgrade path now only targets a `<main>` that directly wraps the route content (`{children}`, `<App />`, `<Outlet />`, or `<slot />`) across all five templates.
+- **Next.js**: scaffolding aborted with `ENOENT ... next.config.mjs`. The template now generates a typed `next.config.ts` (`const nextConfig: NextConfig = {}`) and a plain `next dev` script without `--turbopack`. The adapter now resolves `next.config.ts`/`.mjs`/`.js`, patches the typed config shape, and appends `-p 1420` to any `next dev` script that doesn't already pin a port.

--- a/packages/create-tauri-ui/src/adapters/next.ts
+++ b/packages/create-tauri-ui/src/adapters/next.ts
@@ -1,37 +1,47 @@
+import fs from "node:fs";
 import path from "node:path";
 
 import type { ProjectOptions, TemplateAdapter } from "../types";
 import { PatchError, editFile, editJson } from "../utils";
 
+const NEXT_CONFIG_FILES = ["next.config.ts", "next.config.mjs", "next.config.js"];
+
 export const nextAdapter: TemplateAdapter = {
   name: "next",
   async apply(projectDir: string, _options: ProjectOptions) {
-    editFile(path.join(projectDir, "next.config.mjs"), (content) => {
+    const configFile = NEXT_CONFIG_FILES.find((file) => fs.existsSync(path.join(projectDir, file)));
+
+    if (!configFile) {
+      throw new PatchError("next.config.ts", "Could not find the Next.js config file.");
+    }
+
+    editFile(path.join(projectDir, configFile), (content) => {
       if (content.includes('output: "export"')) {
         return content;
       }
 
-      if (!content.includes("const nextConfig = {}")) {
-        throw new PatchError("next.config.mjs", "Could not find the default Next.js config shape.");
+      const emptyConfig = /const nextConfig(?:\s*:\s*NextConfig)?\s*=\s*\{\}/;
+
+      if (!emptyConfig.test(content)) {
+        throw new PatchError(configFile, "Could not find the default Next.js config shape.");
       }
 
-      return content.replace(
-        "const nextConfig = {}",
-        `const nextConfig = {
+      return content.replace(emptyConfig, (declaration) =>
+        declaration.replace(
+          "{}",
+          `{
   output: "export",
   images: {
     unoptimized: true,
   },
 }`,
+        ),
       );
     });
 
     editJson<Record<string, any>>(path.join(projectDir, "package.json"), (pkg) => {
-      if (pkg.scripts?.dev) {
-        pkg.scripts.dev = pkg.scripts.dev.replace(
-          "next dev --turbopack",
-          "next dev --turbopack -p 1420",
-        );
+      if (pkg.scripts?.dev?.startsWith("next dev") && !pkg.scripts.dev.includes("-p ")) {
+        pkg.scripts.dev = `${pkg.scripts.dev} -p 1420`;
       }
 
       return pkg;

--- a/packages/create-tauri-ui/src/batteries/scroll-container.ts
+++ b/packages/create-tauri-ui/src/batteries/scroll-container.ts
@@ -43,14 +43,22 @@ function ensureCssSnippet(filePath: string, snippet: string) {
   });
 }
 
-function ensureMainWrapper(filePath: string, matcher: string | RegExp, replacement: string) {
+function ensureMainWrapper(
+  filePath: string,
+  innerAnchor: string,
+  matcher: string | RegExp,
+  replacement: string,
+) {
   editFile(filePath, (content) => {
-    if (content.includes(`<main ${SCROLL_CONTAINER_ATTRIBUTE}>`)) {
+    if (content.includes(SCROLL_CONTAINER_ATTRIBUTE)) {
       return content;
     }
 
+    // Only upgrade a <main> that directly wraps the route content. Templates can
+    // contain unrelated <main> elements (e.g. the TanStack Start notFoundComponent),
+    // which must not become the desktop scroll container.
     const upgradedContent = content.replace(
-      new RegExp(`<main(?![^>]*${SCROLL_CONTAINER_ATTRIBUTE})([^>]*)>`),
+      new RegExp(`<main(?![^>]*${SCROLL_CONTAINER_ATTRIBUTE})([^>]*)>(?=\\s*${innerAnchor})`),
       `<main ${SCROLL_CONTAINER_ATTRIBUTE}$1>`,
     );
 
@@ -74,6 +82,7 @@ export async function applyScrollContainer(projectDir: string, options: ProjectO
       ensureCssSnippet(path.join(projectDir, "app/globals.css"), BASE_SCROLL_CSS);
       ensureMainWrapper(
         path.join(projectDir, "app/layout.tsx"),
+        "\\{children\\}",
         /\{children\}/,
         `<main ${SCROLL_CONTAINER_ATTRIBUTE}>{children}</main>`,
       );
@@ -85,6 +94,7 @@ export async function applyScrollContainer(projectDir: string, options: ProjectO
       );
       ensureMainWrapper(
         path.join(projectDir, "src/main.tsx"),
+        "<App \\/>",
         /<App \/>/,
         `<main ${SCROLL_CONTAINER_ATTRIBUTE}><App /></main>`,
       );
@@ -93,6 +103,7 @@ export async function applyScrollContainer(projectDir: string, options: ProjectO
       ensureCssSnippet(path.join(projectDir, "src/styles.css"), BASE_SCROLL_CSS);
       ensureMainWrapper(
         path.join(projectDir, "src/routes/__root.tsx"),
+        "\\{children\\}",
         /\{children\}/,
         `<main ${SCROLL_CONTAINER_ATTRIBUTE}>{children}</main>`,
       );
@@ -101,6 +112,7 @@ export async function applyScrollContainer(projectDir: string, options: ProjectO
       ensureCssSnippet(path.join(projectDir, "app/app.css"), BASE_SCROLL_CSS);
       ensureMainWrapper(
         path.join(projectDir, "app/root.tsx"),
+        "<Outlet \\/>",
         /return <Outlet \/>/,
         `return <main ${SCROLL_CONTAINER_ATTRIBUTE}><Outlet /></main>`,
       );
@@ -109,6 +121,7 @@ export async function applyScrollContainer(projectDir: string, options: ProjectO
       ensureCssSnippet(path.join(projectDir, "src/styles/global.css"), BASE_SCROLL_CSS);
       ensureMainWrapper(
         path.join(projectDir, "src/layouts/main.astro"),
+        "<slot \\/>",
         /<slot \/>/,
         `<main ${SCROLL_CONTAINER_ATTRIBUTE}><slot /></main>`,
       );


### PR DESCRIPTION
## Problem

`bun create tauri-ui` currently fails for two of the five templates because the upstream shadcn templates changed shape:

**TanStack Start** — scaffolding always aborts with:

```
▲  Scaffolding failed
└  Could not mount ExternalLinkGuard in the TanStack Start root route.
```

The generated `src/routes/__root.tsx` now ships a `notFoundComponent` containing its own `<main className="container mx-auto p-4 pt-16">`, declared *before* `RootDocument`. The scroll-container battery's "upgrade an existing `<main>`" regex matched the **first** `<main>` in the file, so it tagged the 404 page's element with `data-ui-scroll-container` instead of wrapping `{children}`. The external-link-guard battery then couldn't find `<main…>{children}</main>` and threw, aborting the whole scaffold.

**Next.js** — scaffolding aborts with `ENOENT: no such file or directory, open '…/next.config.mjs'`. The template now generates a typed `next.config.ts` (`const nextConfig: NextConfig = {}`) and a plain `"dev": "next dev"` script without `--turbopack`, so the static-export patch crashed and the `-p 1420` port rewrite silently no-opped.

## Fix

- `batteries/scroll-container.ts`: the upgrade path now only targets a `<main>` that directly wraps the route content (`{children}`, `<App />`, `<Outlet />`, `<slot />`) via a lookahead anchor passed per template, leaving unrelated `<main>` elements (like the Start 404 page) untouched. Also hardened the idempotency check so a previously upgraded `<main>` carrying extra attributes is still detected.
- `adapters/next.ts`: resolves `next.config.ts`/`.mjs`/`.js` (first match), patches both the typed and untyped empty-config shapes, and appends `-p 1420` to any `next dev` script that doesn't already pin a port.

## Verification

- Reproduced the original failure with `--template start` before the fix.
- After the fix, the exact failing invocation (`--template start --no-starter --size-optimize --workflow`) scaffolds successfully and the generated app passes `bun install && bun run build`.
- Full simple test matrix (`node scripts/test-create-tauri-ui-simple.mjs`) passes for all five templates:

```
- PASS vite (14.5s)
- PASS next (20.2s)
- PASS start (15.4s)
- PASS react-router (15.2s)
- PASS astro (18.4s)
```

- `oxlint` / `oxfmt --check` / `tsc --noEmit` clean (the single pre-existing `libRoot` warning on master is untouched).
- Changeset included (patch bump for `create-tauri-ui`).